### PR TITLE
Ensure ssl on connections

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+0.8.6
+* Use SSL connection
+
 0.8.5
 * Added option to make the widget title link back to the Plaza.
 

--- a/load_data.php
+++ b/load_data.php
@@ -70,7 +70,7 @@
         }
 
 
-        $plaza_link_base = 'http://'.$_GET['subdomain_key'].'.onthecity.org/plaza/'.$item_type_path.'/'; 
+        $plaza_link_base = 'https://'.$_GET['subdomain_key'].'.onthecity.org/plaza/'.$item_type_path.'/'; 
         $plaza_link = $plaza_link_base . $item->id();   
         $item_date = '';
 

--- a/notes.txt
+++ b/notes.txt
@@ -1,1 +1,1 @@
-svn copy http://plugins.svn.wordpress.org/the-city-plaza/trunk/ http://plugins.svn.wordpress.org/the-city-plaza/tags/release-0.8.4 -m "Release 0.8.4"
+svn copy http://plugins.svn.wordpress.org/the-city-plaza/trunk/ http://plugins.svn.wordpress.org/the-city-plaza/tags/release-0.8.6 -m "Release 0.8.6"

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,9 @@ None yet...
 
 == Changelog ==
 
+= 0.8.6 =
+* Ensure SSL on connection to The City.
+
 = 0.8.5 =
 * Added option to make the widget title link back to the Plaza.
 

--- a/the_city_plaza.php
+++ b/the_city_plaza.php
@@ -4,7 +4,7 @@ Plugin Name: The City Plaza Widget
 Plugin URI: http://developer.onthecity.org/thecity-plugins/wordpress/
 Description: This widget allows you to pull your OnTheCity.org plaza information into your WordPress website.
 Author: Wes Hays
-Version: 0.8.5
+Version: 0.8.6
 Author URI: http://www.OnTheCity.org
 */
 


### PR DESCRIPTION
The City is now fully SSL, which broke the hard code http:// paths in a couple of these API calls. Bumped the version to 0.8.6 as well for Wordpress publishing
